### PR TITLE
Fix bug in logic of path param filtering.

### DIFF
--- a/middlewarerule.js
+++ b/middlewarerule.js
@@ -233,7 +233,7 @@ MiddlewareRule.prototype.getCollection = function(params, data, req) {
 		// Exclude path params.
 		if (!this.path.keys) { return true; }
 		return this.path.keys.every(function(pathKeyInfo) {
-			return pathKeyInfo.name === key;
+			return pathKeyInfo.name !== key;
 		});
 	}.bind(this));
 	if (nonSpecialParams.length > 0) {

--- a/test/middlewarerule.spec.js
+++ b/test/middlewarerule.spec.js
@@ -2,9 +2,10 @@
 describe('MiddlewareRule', function() {
 
 	var MiddlewareRule = require('../')().MiddlewareRule;
+	var pathToRegexp = require('path-to-regexp');
 
 	var path = '/foo';
-	var collection, rule, response;
+	var pathAsRegExp, collection, rule, response;
 
 	var prefilterFunc, postfilterFunc;
 	var prefilterData = { filtered: 'prefilter' };
@@ -20,13 +21,14 @@ describe('MiddlewareRule', function() {
 
 	beforeEach(function() {
 		collection = [];
-		rule = new MiddlewareRule(path, collection);
+		pathAsRegExp = pathToRegexp(path + '/:id?(\\?.*)?', undefined, { sensitive: true, strict: false });
+		rule = new MiddlewareRule(pathAsRegExp, collection);
 	});
 
 	describe('constructor', function() {
 
 		it('should save the path', function() {
-			expect(rule.path).toBe(path);
+			expect(rule.path).toBe(pathAsRegExp);
 		});
 
 		it('should save the collection', function() {


### PR DESCRIPTION
I ran into a bug in the logic of `MiddlewareRule.prototype.getCollection()`. I fixed that and improved the setup of the MiddlewareRule unit tests so this situation would actually be covered.
