### PR TITLE
[WIP] Use browser fingerprinting when operating on collection data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ var pathToRegexp = require('path-to-regexp');
 var parseUrl = require('url').parse;
 var pkgName = require('./package.json').name;
 
-function Middleware() {
+function Middleware(opts) {
 	this.MiddlewareRule = MiddlewareRule; // mainly for testing
+	this.opts = extend({}, opts);
 	this.rules = [];
 
 	var minilog = require('minilog');
@@ -41,7 +42,7 @@ function getQueryParams(url) {
 
 // Note: path cannot contain an ":id" placeholder. That is reserved.
 Middleware.prototype.addResource = function(path, collection, opts) {
-	opts = opts || {};
+	opts = extend({}, this.opts, opts);
 	if (typeof path === 'undefined') {
 		throw new Error('A path must be passed to addResource()');
 	}
@@ -185,7 +186,7 @@ Middleware.prototype.useWith = function(app) {
 	this.getMiddleware().map(app.use.bind(app));
 };
 
-module.exports = function() {
-	return new Middleware();
+module.exports = function(opts) {
+	return new Middleware(opts);
 };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "extend": "^3.0.0",
     "minilog": "^3.0.0",
     "minimist": "^1.2.0",
-    "path-to-regexp": "1.2.x"
+    "path-to-regexp": "1.2.x",
+    "sha1": "^1.1.1"
   },
   "devDependencies": {
     "jasmine": "^2.4.1",

--- a/test-server.js
+++ b/test-server.js
@@ -18,7 +18,7 @@ if (opts._.length === 0) {
 }
 
 var createMocks = require('./');
-var mocks = createMocks();
+var mocks = createMocks({ fingerprinting: true });
 mocks.logger.enable();
 
 opts._.forEach(function(module) {

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -17,4 +17,22 @@ describe('module', function() {
 		expect(obj1).not.toBe(obj2);
 	});
 
+	describe('options', function() {
+
+		it('should default to empty options', function() {
+			expect(middleware().opts).toEqual({});
+		});
+
+		it('should accept an options object as an argument', function() {
+			expect(middleware({ foo: true }).opts.foo).toBe(true);
+		});
+
+		it('should pass the options along to addResource()', function() {
+			var m = middleware({ fingerprinting: false });
+			var rule = m.addResource('/foo', []);
+			expect(rule.fingerprinting).toBe(false);
+		});
+
+	});
+
 });


### PR DESCRIPTION
Multiple collections are now tracked, and are hashed according to the User-Agent HTTP header value (using SHA1).

Fingerprinting is turned on by default.

The "collection" property is now gone. Use "collections" instead, with the appropriate SHA1 key.

* tested in sentry-angular-api, etc
* will need to update mocks a bit
